### PR TITLE
SMALL_BIG and LARGE_BIG serialization integrated

### DIFF
--- a/src/ErlangTerm.jl
+++ b/src/ErlangTerm.jl
@@ -166,7 +166,7 @@ end
 
 dig2int(arr) = sum(((i, x),) -> x * 256^(i - 1), pairs(arr))
 dig2int(::Type{Int32}, arr) = Int32(dig2int(arr))
-dig2int(::Type{Int64}, arr) = dig2int(arr)
+dig2int(::Type{Int64}, arr) = sum(((i, x),) -> x * Int64(256)^(i - 1), pairs(arr))
 dig2int(::Type{Int128}, arr) = sum(((i, x),) -> x * Int128(256)^(i - 1), pairs(arr))
 dig2int(::Type{BigInt}, arr) = sum(((i, x),) -> x * BigInt(256)^(i - 1), pairs(arr))
 

--- a/src/ErlangTerm.jl
+++ b/src/ErlangTerm.jl
@@ -285,7 +285,7 @@ function deserialize(io, ::Val{STRING})
 end
 
 function _serialize(io, ::Nothing)
-    write(io, NIL)
+    _serialize(io, :nil)
     io
 end
 

--- a/src/ErlangTerm.jl
+++ b/src/ErlangTerm.jl
@@ -289,4 +289,8 @@ function _serialize(io, ::Nothing)
     io
 end
 
+function _serialize(io, unknown)
+    _serialize(io, repr(unknown))
+end
+
 end # module

--- a/src/ErlangTerm.jl
+++ b/src/ErlangTerm.jl
@@ -12,6 +12,8 @@ const NIL = UInt8(106)
 const STRING = UInt8(107)
 const LIST = UInt8(108)
 const BINARY = UInt8(109)
+const SMALL_BIG = UInt8(110)
+const LARGE_BIG = UInt8(111)
 const MAP = UInt8(116)
 const ATOM_UTF8 = UInt8(118)
 const SMALL_ATOM_UTF8 = UInt8(119)
@@ -58,9 +60,21 @@ function _serialize(io, val::Integer)
     if val > 0 && val <= typemax(UInt8)
         write(io, SMALL_INTEGER)
         write(io, UInt8(val))
-    else
+    elseif abs(val) <= typemax(Int32)
         write(io, INTEGER)
         write(io, hton(Int32(val)))
+    else
+        arr = digits(UInt8, abs(val), base=0x100)
+        n = length(arr)
+        if n < 0x100
+            write(io, SMALL_BIG)
+            write(io, UInt8(n))
+        else
+            write(io, LARGE_BIG)
+            write(io, hton(UInt32(n)))
+        end
+        write(io, UInt8(sign(val) == 1 ? 0 : 1))
+        write(io, arr)
     end
     io
 end
@@ -129,6 +143,33 @@ function deserialize(io, ::Val{BINARY})
     String(read(io, n))
 end
 
+function deserialize(io, ::Val{SMALL_BIG})
+    n = Int(read(io, UInt8))
+    sign = Int32(read(io, UInt8) == 0 ? 1 : -1)
+    arr = Array{UInt8,1}(read(io, n))
+    _bignum(n, sign, arr)
+end
+
+function deserialize(io, ::Val{LARGE_BIG})
+    n = Int(ntoh(read(io, UInt32)))
+    sign = Int32(read(io, UInt8) == 0 ? 1 : -1)
+    arr = Array{UInt8,1}(read(io, n))
+    _bignum(n, sign, arr)
+end
+
+function _bignum(n, sign, arr)
+    itype = n < 4 ? Int32 : 
+            n < 8 ? Int64 :
+            n < 16 ? Int128 : BigInt
+    sign * dig2int(itype, arr)
+end
+
+dig2int(arr) = sum(((i, x),) -> x * 256^(i - 1), pairs(arr))
+dig2int(::Type{Int32}, arr) = Int32(dig2int(arr))
+dig2int(::Type{Int64}, arr) = dig2int(arr)
+dig2int(::Type{Int128}, arr) = sum(((i, x),) -> x * Int128(256)^(i - 1), pairs(arr))
+dig2int(::Type{BigInt}, arr) = sum(((i, x),) -> x * BigInt(256)^(i - 1), pairs(arr))
+
 function _serialize(io, array::AbstractArray)
     if isempty(array)
         write(io, NIL)
@@ -164,7 +205,7 @@ function deserialize(io, ::Val{LIST})
     array
 end
 
-function _serialize(io, dict::Dict)
+    function _serialize(io, dict::Dict)
     write(io, MAP)
     n = length(dict)
     n > typemax(UInt32) && throw(ArgumentError("Dicts with more than $(typemax(UInt32)) pairs cannot be serialized."))
@@ -185,7 +226,7 @@ function deserialize(io, ::Val{MAP})
         key = deserialize(io, Val(keytag))
         valuetag = read(io, UInt8)
         value = deserialize(io, Val(valuetag))
-        push!(dict, key=>value)
+        push!(dict, key => value)
         i += 1
     end
     dict
@@ -209,30 +250,30 @@ function _serialize(io, val::Tuple)
 end
 
 function deserialize(io, ::Val{SMALL_TUPLE})
-    n = Int(ntoh(read(io, UInt8)))
+        n = Int(ntoh(read(io, UInt8)))
     i = 0
     array = []
-    while i < n
+        while i < n
         tag = read(io, UInt8)
-        push!(array, deserialize(io, Val(tag)))
-        i += 1
+push!(array, deserialize(io, Val(tag)))
+    i += 1
     end
     Tuple(array)
 end
-
+    
 function deserialize(io, ::Val{LARGE_TUPLE})
     n = Int(ntoh(read(io, UInt32)))
     i = 0
     array = []
     while i < n
         tag = read(io, UInt8)
-        push!(array, deserialize(io, Val(tag)))
+push!(array, deserialize(io, Val(tag)))
         i += 1
     end
     Tuple(array)
 end
 
-function deserialize(io, ::Val{STRING})
+    function deserialize(io, ::Val{STRING})
     n = Int(ntoh(read(io, UInt16)))
     i = 0
     array = []

--- a/src/ErlangTerm.jl
+++ b/src/ErlangTerm.jl
@@ -226,7 +226,7 @@ function deserialize(io, ::Val{MAP})
         key = deserialize(io, Val(keytag))
         valuetag = read(io, UInt8)
         value = deserialize(io, Val(valuetag))
-        push!(dict, key => value)
+        push!(dict, key=>value)
         i += 1
     end
     dict

--- a/src/ErlangTerm.jl
+++ b/src/ErlangTerm.jl
@@ -260,7 +260,7 @@ function deserialize(io, ::Val{SMALL_TUPLE})
     end
     Tuple(array)
 end
-    
+
 function deserialize(io, ::Val{LARGE_TUPLE})
     n = Int(ntoh(read(io, UInt32)))
     i = 0

--- a/src/ErlangTerm.jl
+++ b/src/ErlangTerm.jl
@@ -205,7 +205,7 @@ function deserialize(io, ::Val{LIST})
     array
 end
 
-    function _serialize(io, dict::Dict)
+function _serialize(io, dict::Dict)
     write(io, MAP)
     n = length(dict)
     n > typemax(UInt32) && throw(ArgumentError("Dicts with more than $(typemax(UInt32)) pairs cannot be serialized."))
@@ -250,13 +250,13 @@ function _serialize(io, val::Tuple)
 end
 
 function deserialize(io, ::Val{SMALL_TUPLE})
-        n = Int(ntoh(read(io, UInt8)))
+    n = Int(ntoh(read(io, UInt8)))
     i = 0
     array = []
-        while i < n
+    while i < n
         tag = read(io, UInt8)
-push!(array, deserialize(io, Val(tag)))
-    i += 1
+        push!(array, deserialize(io, Val(tag)))
+        i += 1
     end
     Tuple(array)
 end
@@ -267,13 +267,13 @@ function deserialize(io, ::Val{LARGE_TUPLE})
     array = []
     while i < n
         tag = read(io, UInt8)
-push!(array, deserialize(io, Val(tag)))
+        push!(array, deserialize(io, Val(tag)))
         i += 1
     end
     Tuple(array)
 end
 
-    function deserialize(io, ::Val{STRING})
+function deserialize(io, ::Val{STRING})
     n = Int(ntoh(read(io, UInt16)))
     i = 0
     array = []
@@ -282,6 +282,11 @@ end
         i += 1
     end
     array
+end
+
+function _serialize(io, ::Nothing)
+    write(io, NIL)
+    io
 end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -145,4 +145,7 @@ using Test
         @test serialize(large_tuple) == large_result
         @test deserialize(serialize(large_tuple)) == large_tuple
     end
+    @testset "Nothing" begin
+        @test serialize(nothing) == UInt8[131, 106]
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -146,6 +146,6 @@ using Test
         @test deserialize(serialize(large_tuple)) == large_tuple
     end
     @testset "Nothing" begin
-        @test serialize(nothing) == UInt8[131, 106]
+        @test serialize(nothing) == UInt8[131, 100, 0, 3, 110, 105, 108]
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -146,6 +146,6 @@ using Test
         @test deserialize(serialize(large_tuple)) == large_tuple
     end
     @testset "Nothing" begin
-        @test serialize(nothing) == UInt8[131, 119, 0, 3, 110, 105, 108]
+        @test serialize(nothing) == UInt8[131, 119, 3, 110, 105, 108]
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -146,6 +146,6 @@ using Test
         @test deserialize(serialize(large_tuple)) == large_tuple
     end
     @testset "Nothing" begin
-        @test serialize(nothing) == UInt8[131, 100, 0, 3, 110, 105, 108]
+        @test serialize(nothing) == UInt8[131, 119, 0, 3, 110, 105, 108]
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,7 @@ using Test
         @test deserialize(serialize(256)) == 256
     end
     @testset "Small Big, Int64" begin
-        i = Int(0x100000000)
+        i = Int64(0x100000000)
         @test serialize(i) == UInt8[131, 110, 5, 0, 0, 0, 0, 0, 1]
         @test deserialize(serialize(i)) == i
         @test typeof(deserialize(serialize(i))) == Int64
@@ -26,7 +26,7 @@ using Test
     end
     @testset "Small Big, Int128" begin
         i = Int128(0x10000000000000000)
-        @test serialize(i) == UInt8[131, 110, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+    @test serialize(i) == UInt8[131, 110, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
         @test deserialize(serialize(i)) == i
         @test typeof(deserialize(serialize(i))) == Int128
         @test serialize(-i) == UInt8[131, 110, 9, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,42 @@ using Test
         @test serialize(256) == UInt8[131, 98, 0, 0, 1, 0]
         @test deserialize(serialize(256)) == 256
     end
+    @testset "Small Big, Int64" begin
+        i = Int(0x100000000)
+        @test serialize(i) == UInt8[131, 110, 5, 0, 0, 0, 0, 0, 1]
+        @test deserialize(serialize(i)) == i
+        @test typeof(deserialize(serialize(i))) == Int64
+        @test serialize(-i) == UInt8[131, 110, 5, 1, 0, 0, 0, 0, 1]
+        @test deserialize(serialize(-i)) == -i
+        @test typeof(deserialize(serialize(-i))) == Int64
+    end
+    @testset "Small Big, Int128" begin
+        i = Int128(0x10000000000000000)
+        @test serialize(i) == UInt8[131, 110, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+        @test deserialize(serialize(i)) == i
+        @test typeof(deserialize(serialize(i))) == Int128
+        @test serialize(-i) == UInt8[131, 110, 9, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+        @test deserialize(serialize(-i)) == -i
+        @test typeof(deserialize(serialize(-i))) == Int128
+    end
+    @testset "Small Big, BigInt" begin
+        i = BigInt(16)^99     # 100 byte integer
+        @test serialize(i)[1:5] == UInt8[131, 110, 50, 0, 0]
+        @test deserialize(serialize(i)) == i
+        @test typeof(deserialize(serialize(i))) == BigInt
+        @test serialize(-i)[1:5] == UInt8[131, 110, 50, 1, 0]
+        @test deserialize(serialize(-i)) == -i
+        @test typeof(deserialize(serialize(-i))) == BigInt
+    end
+    @testset "Large Big, BigInt" begin
+        i = BigInt(16)^599    # 600 byte integer
+        @test serialize(i)[1:8] == UInt8[131, 111, 0, 0, 1, 44, 0, 0]
+        @test deserialize(serialize(i)) == i
+        @test typeof(deserialize(serialize(i))) == BigInt
+        @test serialize(-i)[1:8] == UInt8[131, 111, 0, 0, 1, 44, 1, 0]
+        @test deserialize(serialize(-i)) == -i
+        @test typeof(deserialize(serialize(-i))) == BigInt
+    end
     @testset "Float" begin
         @test serialize(1.0) == UInt8[131, 70, 63, 240, 0, 0, 0, 0, 0, 0]
         @test deserialize(serialize(1.0)) == 1.0


### PR DESCRIPTION
Integrated serialization of bignums described in 12.19 and 12.20 of http://erlang.org/doc/apps/erts/erl_ext_dist.html. 
- Int64, Int128 and BigInt can be transferred back and forth between Erlang and Julia.
- Has been tested with Erlang.